### PR TITLE
better string interpolation support scoping.

### DIFF
--- a/Data/Configurator.hs
+++ b/Data/Configurator.hs
@@ -290,8 +290,8 @@ interpolate pfx s env
     | otherwise = return s
  where
   lookupInterp name =
-          H.lookup name env
-      <|> H.lookup (pfx `T.append` name) env
+          H.lookup (pfx `T.append` name) env
+      <|> H.lookup name env
 
   interpret (Literal x)   = return (fromText x)
   interpret (Interpolate name) =

--- a/Data/Configurator.hs
+++ b/Data/Configurator.hs
@@ -291,15 +291,13 @@ interpolate pfx s env
     | otherwise = return s
  where
   lookupEnv name = msum $ map (flip H.lookup env) fullnames
-    where fullnames = if T.null pfx
-                         then [name]
-                         else map (T.intercalate ".") -- ["a.b.c.x","a.b.x","a.x","x"]
-                            . map (reverse . (name:)) -- [["a","b","c","x"],["a","b","x"],["a","x"],["x"]]
-                            . tails                   -- [["c","b","a"],["b","a"],["a"],[]]
-                            . reverse                 -- ["c","b","a"]
-                            . filter (not . T.null)   -- ["a","b","c"]
-                            . T.split (=='.')         -- ["a","b","c",""]
-                            $ pfx                     -- "a.b.c."
+    where fullnames = map (T.intercalate ".")     -- ["a.b.c.x","a.b.x","a.x","x"]
+                    . map (reverse . (name:)) -- [["a","b","c","x"],["a","b","x"],["a","x"],["x"]]
+                    . tails                   -- [["c","b","a"],["b","a"],["a"],[]]
+                    . reverse                 -- ["c","b","a"]
+                    . filter (not . T.null)   -- ["a","b","c"]
+                    . T.split (=='.')         -- ["a","b","c",""]
+                    $ pfx                     -- "a.b.c."
 
   interpret (Literal x)   = return (fromText x)
   interpret (Interpolate name) =

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -148,10 +148,15 @@ interpTest = withLoad [Required "resources/pathological.cfg"] $ \ cfg -> do
 scopedInterpTest :: Assertion
 scopedInterpTest = withLoad [Required "resources/interp.cfg"] $ \ cfg -> do
     home    <- getEnv "HOME"
-    exec    <- lookup cfg "myprogram.exec"
-    stdout' <- lookup cfg "myprogram.stdout"
-    assertEqual "myprogram.exec" exec (Just $ home++"/services/myprogram/myprogram")
-    assertEqual "myprogram.stdout" stdout' (Just $ home++"/services/myprogram/stdout")
+
+    lookup cfg "myprogram.exec"
+        >>= assertEqual "myprogram.exec" (Just $ home++"/services/myprogram/myprogram")
+
+    lookup cfg "myprogram.stdout"
+        >>= assertEqual "myprogram.stdout" (Just $ home++"/services/myprogram/stdout")
+
+    lookup cfg "top.layer1.layer2.dir"
+        >>= assertEqual "nested scope" (Just $ home++"/top/layer1/layer2")
 
 importTest :: Assertion
 importTest = withLoad [Required "resources/import.cfg"] $ \ cfg -> do

--- a/tests/configurator-tests.cabal
+++ b/tests/configurator-tests.cabal
@@ -10,7 +10,7 @@ Executable configurator-test
                      directory,
                      HUnit,
                      text,
-                     attoparsec-text,
+                     attoparsec,
                      unordered-containers,
                      unix-compat,
                      hashable,

--- a/tests/resources/interp.cfg
+++ b/tests/resources/interp.cfg
@@ -8,3 +8,13 @@ myprogram {
         stderr = "$(root)/stderr"
         delay = 1
 }
+dir = "$(HOME)"
+top {
+    dir = "$(dir)/top"
+    layer1 {
+        dir = "$(dir)/layer1"
+        layer2 {
+            dir = "$(dir)/layer2"
+        }
+    }
+}

--- a/tests/resources/interp.cfg
+++ b/tests/resources/interp.cfg
@@ -1,4 +1,5 @@
 services = "$(HOME)/services"
+root = "can be overwritten by inner block."
 myprogram {
         name = "myprogram"
         root = "$(services)/$(name)"

--- a/tests/resources/interp.cfg
+++ b/tests/resources/interp.cfg
@@ -1,0 +1,9 @@
+services = "$(HOME)/services"
+myprogram {
+        name = "myprogram"
+        root = "$(services)/$(name)"
+        exec = "$(root)/$(name)"
+        stdout = "$(root)/stdout"
+        stderr = "$(root)/stderr"
+        delay = 1
+}


### PR DESCRIPTION
This feature can make config file more clean, the follow is an example config file for angel :

```
root = "$(HOME)/services"
myprogram {
        name = "myprogram"
        root = "$(root)/$(name)"
        exec = "$(root)/$(name)"
        stdout = "$(root)/stdout"
        stderr = "$(root)/stderr"
        delay = 1
}
```
