### PR TITLE
Allow instance Configured [a] without OverlappingInstances

### DIFF
--- a/Data/Configurator/Instances.hs
+++ b/Data/Configurator/Instances.hs
@@ -91,8 +91,11 @@ instance Configured T.Text where
     convert (String v) = Just v
     convert _          = Nothing
 
-instance Configured [Char] where
-    convert = fmap T.unpack . convert
+instance Configured Char where
+    convert (String txt) | T.length txt == 1 = Just $ T.head txt
+    convert _ = Nothing
+
+    convertList = fmap T.unpack . convert
 
 instance Configured L.Text where
     convert = fmap L.fromStrict . convert

--- a/Data/Configurator/Types.hs
+++ b/Data/Configurator/Types.hs
@@ -14,7 +14,7 @@ module Data.Configurator.Types
     , Config
     , Name
     , Value(..)
-    , Configured(..)
+    , Configured, convert
     , Worth(..)
     -- * Exceptions
     , ConfigError(..)

--- a/Data/Configurator/Types/Internal.hs
+++ b/Data/Configurator/Types/Internal.hs
@@ -131,6 +131,13 @@ instance Hashable Pattern where
 class Configured a where
     convert :: Value -> Maybe a
 
+    convertList :: Value -> Maybe [a]
+    convertList (List xs) = mapM convert xs
+    convertList _         = Nothing
+
+instance Configured a => Configured [a] where
+    convert = convertList
+
 -- | An error occurred while processing a configuration file.
 data ConfigError = ParseError FilePath String
                    deriving (Show, Typeable)

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -133,10 +133,19 @@ typesTest = withLoad [Required "resources/pathological.cfg"] $ \ cfg -> do
     assertEqual "word64" asWord64 (Just 1)
 
     asTextBad <- lookup cfg "aa" :: IO (Maybe Text)
-    assertEqual "word64" asTextBad Nothing
+    assertEqual "bad text" asTextBad Nothing
 
     asTextGood <- lookup cfg "ab" :: IO (Maybe Text)
-    assertEqual "word64" asTextGood (Just "foo")
+    assertEqual "good text" asTextGood (Just "foo")
+
+    asStringGood <- lookup cfg "ab" :: IO (Maybe String)
+    assertEqual "string" asStringGood (Just "foo")
+
+    asInts <- lookup cfg "xs" :: IO (Maybe [Int])
+    assertEqual "ints" asInts (Just [1,2,3])
+
+    asChar <- lookup cfg "c" :: IO (Maybe Char)
+    assertEqual "char" asChar (Just 'x')
 
 interpTest :: Assertion
 interpTest = withLoad [Required "resources/pathological.cfg"] $ \ cfg -> do
@@ -165,4 +174,3 @@ reloadTest = withReload [Required "resources/pathological.cfg"] $ \[Just f] cfg 
     assertEqual "notify happened" r1 (Just ())
     r2 <- takeMVarTimeout 2000 wongly
     assertEqual "notify not happened" r2 Nothing
-

--- a/tests/resources/pathological.cfg
+++ b/tests/resources/pathological.cfg
@@ -34,3 +34,6 @@ ag { q-e { i_u9 { a=false}}}
 
 ba = "$(HOME)"
 
+xs = [1,2,3]
+
+c = "x"


### PR DESCRIPTION
This is an alternative for #7 which doesn't require the OverlappingInstances extension. It uses the standard [showList](http://hackage.haskell.org/packages/archive/base/latest/doc/html/Prelude.html#v:showList) trick.
