### PR TITLE
Added functions and types for generating config file

### DIFF
--- a/Data/Configurator/Types.hs
+++ b/Data/Configurator/Types.hs
@@ -22,6 +22,9 @@ module Data.Configurator.Types
     -- * Notification of configuration changes
     , Pattern
     , ChangeHandler
+    -- * Types for generating config files
+    , FileEntry(..)
+    , ConfigFile
     ) where
 
 import Data.Configurator.Types.Internal

--- a/Data/Configurator/Types/Internal.hs
+++ b/Data/Configurator/Types/Internal.hs
@@ -29,6 +29,8 @@ module Data.Configurator.Types.Internal
     , exact
     , prefix
     , ChangeHandler
+    , FileEntry(..)
+    , ConfigFile
     ) where
 
 import Control.Exception
@@ -214,3 +216,14 @@ data Value = Bool Bool
 data Interpolate = Literal Text
                  | Interpolate Text
                    deriving (Eq, Show)
+
+-- | Single entry of a desired configuration to be written to file.
+data FileEntry = FComment Text
+               | FNewline
+               | FImport Path
+               | FBind Name Text
+               | FGroup Name ConfigFile -- arbitrary grouping
+               deriving (Eq)
+
+-- | Representation of a configuration file for writing to disk.
+type ConfigFile = [FileEntry]

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -172,7 +172,7 @@ testConfig =
     [ FComment "This is a test comment"
     , FComment "And here is a new one"
     , FNewline
-    , FImport "File/DummyConfigDir/Conf.config"
+    , FImport "pathological.cfg"
     , FBind "myBindVar" "\"here's my bind string\""
     , FBind "myInt" "32 # This is a trailing comment as part of a bind"
     , FComment "Ok, let's try a group now"
@@ -182,7 +182,7 @@ testConfig =
         , FBind "group1b" "90"
         , FGroup "group2"
             [ FComment "I am nested!"
-            , FImport "nested/import.config"
+            , FImport "import.cfg"
             , FBind "group2a" "\"nested var\""
             ]
         , FComment "End the group"
@@ -197,6 +197,6 @@ testConfig =
 writeTest :: Assertion
 writeTest = do
     writeConfigFile "resources/testoutput.cfg" testConfig
-    withLoad [Required "resources/pathological.cfg"] $ \_cfg -> do
+    withLoad [Required "resources/testoutput.cfg"] $ \_cfg -> do
         assertBool "Failed to load write test file if here" True
     

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -197,5 +197,6 @@ testConfig =
 writeTest :: Assertion
 writeTest = do
     writeConfigFile "resources/testoutput.cfg" testConfig
-    assertBool "Maybe this is true" True
+    withLoad [Required "resources/pathological.cfg"] $ \_cfg -> do
+        assertBool "Failed to load write test file if here" True
     

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -30,7 +30,8 @@ tests = TestList [
     "types"  ~: typesTest,
     "interp" ~: interpTest,
     "import" ~: importTest,
-    "reload" ~: reloadTest
+    "reload" ~: reloadTest,
+    "write"  ~: writeTest
     ]
 
 withLoad :: [Worth FilePath] -> (Config -> IO ()) -> IO ()
@@ -166,3 +167,35 @@ reloadTest = withReload [Required "resources/pathological.cfg"] $ \[Just f] cfg 
     r2 <- takeMVarTimeout 2000 wongly
     assertEqual "notify not happened" r2 Nothing
 
+testConfig :: ConfigFile
+testConfig =
+    [ FComment "This is a test comment"
+    , FComment "And here is a new one"
+    , FNewline
+    , FImport "File/DummyConfigDir/Conf.config"
+    , FBind "myBindVar" "\"here's my bind string\""
+    , FBind "myInt" "32 # This is a trailing comment as part of a bind"
+    , FComment "Ok, let's try a group now"
+    , FGroup "group1"
+        [ FComment "Starting group 1"
+        , FBind "group1a" "7"
+        , FBind "group1b" "90"
+        , FGroup "group2"
+            [ FComment "I am nested!"
+            , FImport "nested/import.config"
+            , FBind "group2a" "\"nested var\""
+            ]
+        , FComment "End the group"
+        ]
+    , FNewline
+    , FComment "A couple more binds for good measure"
+    , FBind "penultimate" "\"almost\""
+    , FBind "final" "\"there\""
+    ]
+
+
+writeTest :: Assertion
+writeTest = do
+    writeConfigFile "resources/testoutput.cfg" testConfig
+    assertBool "Maybe this is true" True
+    

--- a/tests/configurator-tests.cabal
+++ b/tests/configurator-tests.cabal
@@ -10,7 +10,7 @@ Executable configurator-test
                      directory,
                      HUnit,
                      text,
-                     attoparsec-text,
+                     attoparsec,
                      unordered-containers,
                      unix-compat,
                      hashable,


### PR DESCRIPTION
I added some functions and types for generating a config file.  Below is the sample output from the a new writeTest:

```
# This is a test comment
# And here is a new one

import "pathological.cfg"
myBindVar = "here's my bind string"
myInt = 32 # This is a trailing comment as part of a bind
# Ok, let's try a group now
group1 {
  # Starting group 1
  group1a = 7
  group1b = 90
  group2 {
    # I am nested!
    import "import.cfg"
    group2a = "nested var"
  }
  # End the group
}

# A couple more binds for good measure
penultimate = "almost"
final = "there"
```

It's pretty rudimentary but I expect it to flexible enough (if not convenient) to handle most use cases.  The default tab size of two spaces is not currently configurable.
