### PR TITLE
Add support for colons (':') in identifier names.

### DIFF
--- a/Data/Configurator.hs
+++ b/Data/Configurator.hs
@@ -416,8 +416,8 @@ empty = Config "" $ unsafePerformIO $ do
 -- > HerList = [1, "foo", off]
 --
 -- A name must begin with a Unicode letter, which is followed by zero
--- or more of a Unicode alphanumeric code point, hyphen \"@-@\", or
--- underscore \"@_@\".
+-- or more of a Unicode alphanumeric code point, hyphen \"@-@\",
+-- underscore \"@_@\", or colon \"@:@\".
 --
 -- Bindings are created or overwritten in the order in which they are
 -- encountered.  It is legitimate for a name to be bound multiple

--- a/Data/Configurator/Parser.hs
+++ b/Data/Configurator/Parser.hs
@@ -75,7 +75,7 @@ ident = do
     throw (ParseError "" $ "reserved word (" ++ show n ++ ") used as identifier")
   return n
  where
-  isCont c = isAlphaNum c || c == '_' || c == '-'
+  isCont c = isAlphaNum c || c == '_' || c == '-' || c == ':'
 
 value :: Parser Value
 value = mconcat [

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -105,6 +105,15 @@ loadTest =
     deep <- lookup cfg "ag.q-e.i_u9.a"
     assertEqual "deep bool" deep (Just False :: Maybe Bool)
 
+    adcolon <- lookup cfg "a:d"
+    assertEqual "colon identifiers" adcolon (Just False :: Maybe Bool)
+
+    abc <- lookup cfg "a:b:c"
+    assertEqual "multiple colon identifiers" abc (Just "hello" :: Maybe Text)
+
+    c <- lookup cfg "c:"
+    assertEqual "colon identifiers without suffix or space" c (Just 1 :: Maybe Int)
+
 typesTest :: Assertion
 typesTest =
   withLoad "pathological.cfg" $ \cfg -> do

--- a/tests/resources/pathological.cfg
+++ b/tests/resources/pathological.cfg
@@ -37,3 +37,7 @@ ba = "$(HOME)"
 xs = [1,2,3]
 
 c = "x"
+
+a:d = false
+a:b:c = "hello"
+c:=1


### PR DESCRIPTION
I'm using configurator to drive a rake-like task management tool (which perhaps doesn't matter, but:) and one feature I have is to extend the commands with project specific stuff, like so:

```
commands {
  command1 = "some shell commands"
  command2 = "..."
}
```

Which works out well, except that the namespacing for commands are colons, and so I want to be able to write something like:

```
commands {
  db:migrate:production = "..."
}
```

But I can't, because colons aren't valid in identifiers. There doesn't seem to be any reason for them not to be legal (they don't appear anywhere else in the grammar or semantics), and it would be really helpful to me (and perhaps others!). 

So this PR adds that support (and updates documentation / test suite).
