### PR TITLE
support string interpolation within Lists, nested Lists

### DIFF
--- a/Data/Configurator.hs
+++ b/Data/Configurator.hs
@@ -270,11 +270,13 @@ flatten roots files = foldM doPath H.empty roots
         Nothing -> return m
         Just ds -> foldM (directive pfx (worth f)) m ds
 
-  directive pfx _ m (Bind name (String value)) = do
-      v <- interpolate pfx value m
-      return $! H.insert (T.append pfx name) (String v) m
-  directive pfx _ m (Bind name value) =
-      return $! H.insert (T.append pfx name) value m
+  directive pfx _ m (Bind name value) = do
+      vs <- interpStrings value
+      return $! H.insert (T.append pfx name) vs m
+    where
+      interpStrings (List vs) = List <$> mapM interpStrings vs
+      interpStrings (String v) = String <$> interpolate pfx v m
+      interpStrings v = return v 
   directive pfx f m (Group name xs) = foldM (directive pfx' f) m xs
       where pfx' = T.concat [pfx, name, "."]
   directive pfx f m (Import path) =

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -160,8 +160,12 @@ interpTest :: Assertion
 interpTest =
   withLoad "pathological.cfg" $ \cfg -> do
     home    <- getEnv "HOME"
+
     cfgHome <- lookup cfg "ba"
     assertEqual "home interp" (Just home) cfgHome
+
+    lookup cfg "xsinterp" >>= 
+      assertEqual "nested home interp" (Just [[home]])
 
 scopedInterpTest :: Assertion
 scopedInterpTest = withLoad "interp.cfg" $ \cfg -> do

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -199,7 +199,7 @@ reloadTest =
     subscribe cfg "dongly" $ \ _ _ -> putMVar dongly ()
     subscribe cfg "wongly" $ \ _ _ -> putMVar wongly ()
     L.appendFile f "\ndongly = 1"
-    r1 <- takeMVarTimeout 2000 dongly
-    assertEqual "notify happened" r1 (Just ())
-    r2 <- takeMVarTimeout 2000 wongly
-    assertEqual "notify not happened" r2 Nothing
+    r1 <- takeMVarTimeout 5000 dongly
+    assertEqual "notify happened" (Just ()) r1
+    r2 <- takeMVarTimeout 5000 wongly
+    assertEqual "notify not happened" Nothing r2

--- a/tests/resources/pathological.cfg
+++ b/tests/resources/pathological.cfg
@@ -34,6 +34,8 @@ ag { q-e { i_u9 { a=false}}}
 
 ba = "$(HOME)"
 
+xsinterp = [["$(HOME)"]]
+
 xs = [1,2,3]
 
 c = "x"


### PR DESCRIPTION
This PR implements string interpolation within `List` and nested `List`s. 

Includes tests! (ok, _a_ test)

Gist describing the issue that prompted this PR:
https://gist.github.com/ramirez7/a963a5745f74d7e76b95ddb19615397d

resolves #21